### PR TITLE
fixJarFileBug

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -273,6 +273,10 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void updatePhotoPathSavedInMasterList() {
         final File folder = new File(FILE_SAVED_PARENT_PATH);
+        if (!folder.exists()) {
+            return;
+        }
+
         if (!folder.isDirectory()) {
             assert false : "The File is not the default folder to save photos!";
         }


### PR DESCRIPTION
Fix problem:
The jar file will hang if the original photo folder hasn't been created when it tries to delete the unused photos.