### PR TITLE
Allowed for empty string as valid timetable URL

### DIFF
--- a/src/main/java/seedu/address/model/person/timetable/Timetable.java
+++ b/src/main/java/seedu/address/model/person/timetable/Timetable.java
@@ -59,12 +59,18 @@ public class Timetable {
     public Timetable(String url) throws IllegalValueException {
         requireNonNull(url);
         String trimmedUrl = url.trim();
-        if (trimmedUrl == "") {
-            trimmedUrl = "http://modsn.us/5tN3z";
+
+        // If no url provided, returns an empty timetable
+        if (trimmedUrl.equals("")) {
+            this.value = "";
+            this.timetable = new TimetableInfo();
+            return;
         }
+
         if (!isValidUrl(trimmedUrl)) {
             throw new IllegalValueException(MESSAGE_TIMETABLE_URL_CONSTRAINTS);
         }
+
         this.value = trimmedUrl;
         this.timetable = parseUrl(trimmedUrl);
     }


### PR DESCRIPTION
Closes #203.

Empty string passed into timetable constructor is now taken as an empty timetable.