### PR TITLE
UI Fixes and Enhancements

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -164,17 +164,6 @@ public class MainWindow extends UiPart<Region> {
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 
-    /**
-     *
-     */
-    public void loadBorders() {
-        personListPanelPlaceholder.setStyle("-fx-border-color:red");
-        tagListPanelPlaceholder.setStyle("-fx-border-color:red");
-        personInfoPlaceholder.setStyle("-fx-border-color:blue");
-        infoPlaceholder.setStyle("-fx-border-color:yellow");
-        commandBoxPlaceholder.setStyle("-fx-border-color:aqua");
-    }
-
     void hide() {
         primaryStage.hide();
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -164,6 +164,17 @@ public class MainWindow extends UiPart<Region> {
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 
+    /**
+     *
+     */
+    public void loadBorders() {
+        personListPanelPlaceholder.setStyle("-fx-border-color:red");
+        tagListPanelPlaceholder.setStyle("-fx-border-color:green");
+        personInfoPlaceholder.setStyle("-fx-border-color:blue");
+        infoPlaceholder.setStyle("-fx-border-color:yellow");
+        commandBoxPlaceholder.setStyle("-fx-border-color:aqua");
+    }
+
     void hide() {
         primaryStage.hide();
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -169,7 +169,7 @@ public class MainWindow extends UiPart<Region> {
      */
     public void loadBorders() {
         personListPanelPlaceholder.setStyle("-fx-border-color:red");
-        tagListPanelPlaceholder.setStyle("-fx-border-color:green");
+        tagListPanelPlaceholder.setStyle("-fx-border-color:red");
         personInfoPlaceholder.setStyle("-fx-border-color:blue");
         infoPlaceholder.setStyle("-fx-border-color:yellow");
         commandBoxPlaceholder.setStyle("-fx-border-color:aqua");

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -57,7 +57,6 @@ public class UiManager extends ComponentManager implements Ui {
             mainWindow = new MainWindow(primaryStage, config, prefs, logic);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
-            mainWindow.loadBorders();
 
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -56,12 +56,18 @@ public class UiManager extends ComponentManager implements Ui {
             mainWindow = new MainWindow(primaryStage, config, prefs, logic);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
+            mainWindow.loadBorders();
 
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));
             showFatalErrorDialogAndShutdown("Fatal error during initializing", e);
         }
     }
+
+        /**
+         *
+         */
+
 
     @Override
     public void stop() {

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -51,6 +51,7 @@ public class UiManager extends ComponentManager implements Ui {
 
         //Set the application icon.
         primaryStage.getIcons().add(getImage(ICON_APPLICATION));
+        primaryStage.setMaximized(true);
 
         try {
             mainWindow = new MainWindow(primaryStage, config, prefs, logic);

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -86,9 +86,9 @@
 
 // horizontal divider above timetable
 .split-pane:vertical .split-pane-divider {
-    -fx-background-color: derive(#383838, 50%);
-    -fx-background-insets: 3;
+    -fx-background-color: #383838;
     -fx-border-color: transparent transparent transparent transparent;
+    -fx-effect: dropshadow( gaussian , rgba(0,0,0,0.7) , 10,0,0,-7 );
 }
 
 .split-pane {
@@ -134,7 +134,7 @@
 
 .list-cell:filled:selected {
     -fx-background-color: #3f5e70;
-    -fx-effect: dropshadow( gaussian , rgba(0,0,0,0.7) , 10,0,5,5 );
+    -fx-effect: dropshadow( gaussian , rgba(0,0,0,0.7) , 5,0,5,5 );
 }
 
 .list-cell:filled:selected #cardPane {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -86,9 +86,9 @@
 
 // horizontal divider above timetable
 .split-pane:vertical .split-pane-divider {
-    -fx-background-color: #383838;
+    -fx-background-color: derive(#383838, 50%);
+    -fx-background-insets: 3;
     -fx-border-color: transparent transparent transparent transparent;
-    -fx-effect: dropshadow( gaussian , rgba(0,0,0,0.7) , 10,0,0,-7 );
 }
 
 .split-pane {
@@ -254,6 +254,11 @@
 /* @@author */
 .anchor-pane {
      -fx-background-color: #383838;
+}
+
+.person-info-panel {
+     -fx-background-color: #383838;
+     -fx-effect: dropshadow( gaussian , rgba(0,0,0,0.7) , 10,0,3,3 );
 }
 
 .pane-with-border {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -84,8 +84,10 @@
     -fx-border-color: transparent transparent transparent transparent;
 }
 
+// horizontal divider above timetable
 .split-pane:vertical .split-pane-divider {
-    -fx-background-color: #383838;
+    -fx-background-color: derive(#383838, 50%);
+    -fx-background-insets: 3;
     -fx-border-color: transparent transparent transparent transparent;
 }
 

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -86,9 +86,9 @@
 
 // horizontal divider above timetable
 .split-pane:vertical .split-pane-divider {
-    -fx-background-color: #E0E0E0;
-    -fx-background-insets: 3;
+    -fx-background-color: #FAFAFA;
     -fx-border-color: transparent transparent transparent transparent;
+    -fx-effect: dropshadow( gaussian , rgba(0,0,0,0.7) , 10,0,0,-7 );
 }
 
 .split-pane {

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -84,8 +84,10 @@
     -fx-border-color: transparent transparent transparent transparent;
 }
 
+// horizontal divider above timetable
 .split-pane:vertical .split-pane-divider {
-    -fx-background-color: #FAFAFA;
+    -fx-background-color: #E0E0E0;
+    -fx-background-insets: 3;
     -fx-border-color: transparent transparent transparent transparent;
 }
 

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -86,9 +86,9 @@
 
 // horizontal divider above timetable
 .split-pane:vertical .split-pane-divider {
-    -fx-background-color: #FAFAFA;
+    -fx-background-color: #E0E0E0;
+    -fx-background-insets: 3;
     -fx-border-color: transparent transparent transparent transparent;
-    -fx-effect: dropshadow( gaussian , rgba(0,0,0,0.7) , 10,0,0,-7 );
 }
 
 .split-pane {
@@ -253,6 +253,11 @@
 /* @@author */
 .anchor-pane {
      -fx-background-color: #FAFAFA;
+}
+
+.person-info-panel {
+     -fx-background-color: #FAFAFA;
+     -fx-effect: dropshadow( gaussian , rgba(0,0,0,0.7) , 10,0,3,3 );
 }
 
 .pane-with-border {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!-- @@author April0616 -->
+
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Menu?>
@@ -10,63 +12,56 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
-<!-- @@author April0616 -->
-<VBox xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
     <stylesheets>
-        <URL value="@Extensions.css"/>
+        <URL value="@Extensions.css" />
     </stylesheets>
     <MenuBar fx:id="menuBar" maxHeight="22.0" prefHeight="22.0" prefWidth="2000.0" VBox.vgrow="NEVER">
         <Menu mnemonicParsing="false" text="File">
-            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit"/>
+            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
         </Menu>
         <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help"/>
+            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
         </Menu>
     </MenuBar>
-    <HBox prefWidth="1020.0">
-        <VBox fx:id="personList" minWidth="200" prefWidth="250.0">
-            <StackPane fx:id="personListPanelPlaceholder" prefWidth="145.0" VBox.vgrow="ALWAYS"/>
+    <HBox>
+        <VBox fx:id="personList">
+            <StackPane fx:id="personListPanelPlaceholder" minWidth="255.0" VBox.vgrow="ALWAYS" />
         </VBox>
         <AnchorPane>
 
-            <SplitPane dividerPositions="0.2" orientation="VERTICAL" prefWidth="2000" AnchorPane.bottomAnchor="0.0"
-                       AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <SplitPane dividerPositions="0.2" orientation="VERTICAL" prefWidth="2000.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
 
                 <!-- @@author -->
-                <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" minHeight="50.0" prefHeight="290.0"
-                           prefWidth="870.0">
+                <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" minHeight="50.0" prefHeight="290.0" prefWidth="870.0">
                     <VBox minWidth="335.0" prefHeight="290.0" prefWidth="435.0" SplitPane.resizableWithParent="true">
                         <padding>
-                            <Insets bottom="10" left="10" right="10" top="10"/>
+                            <Insets bottom="10" left="10" right="10" top="10" />
                         </padding>
 
                         <!-- @@author nbriannl -->
-                        <StackPane fx:id="tagListPanelPlaceholder" maxHeight="80.0" minHeight="20.0" prefHeight="40.0"
-                                   prefWidth="549.0" styleClass="pane-with-border">
+                        <StackPane fx:id="tagListPanelPlaceholder" maxHeight="80.0" minHeight="20.0" prefHeight="40.0" prefWidth="549.0" styleClass="pane-with-border">
                             <padding>
-                                <Insets bottom="5" left="10" right="10" top="5"/>
+                                <Insets bottom="5" left="10" right="10" top="5" />
                             </padding>
                         </StackPane>
                         <StackPane fx:id="personInfoPlaceholder" VBox.vgrow="ALWAYS">
                             <padding>
-                                <Insets left="10" right="5" top="5"/>
+                                <Insets left="10" right="5" top="5" />
                             </padding>
                         </StackPane>
 
                     </VBox>
                     <VBox minWidth="200" prefWidth="323.0">
 
-                        <StackPane fx:id="commandBoxPlaceholder" minWidth="100" prefWidth="305.0"
-                                   styleClass="pane-with-border">
+                        <StackPane fx:id="commandBoxPlaceholder" minWidth="100" prefWidth="305.0" styleClass="pane-with-border">
                             <padding>
-                                <Insets bottom="5" left="10" right="10" top="5"/>
+                                <Insets bottom="5" left="10" right="10" top="5" />
                             </padding>
                         </StackPane>
-                        <StackPane fx:id="resultDisplayPlaceholder" minWidth="100" prefWidth="320.0"
-                                   styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                        <StackPane fx:id="resultDisplayPlaceholder" minWidth="100" prefWidth="320.0" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                             <padding>
-                                <Insets bottom="5" left="10" right="10" top="5"/>
+                                <Insets bottom="5" left="10" right="10" top="5" />
                             </padding>
                         </StackPane>
                     </VBox>
@@ -74,11 +69,11 @@
                 <!-- @@author zacharytang -->
                 <StackPane fx:id="infoPlaceholder" styleClass="pane-with-border">
                     <padding>
-                        <Insets bottom="10" left="10" right="10" top="10"/>
+                        <Insets bottom="10" left="10" right="10" top="10" />
                     </padding>
                 </StackPane>
             </SplitPane>
         </AnchorPane>
     </HBox>
-    <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
+    <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
 </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -34,7 +34,7 @@
 
                 <!-- @@author -->
                 <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4269269269269269" minHeight="50.0" prefHeight="290.0" prefWidth="870.0">
-                    <VBox minHeight="81.0" minWidth="650.0" prefHeight="81.0" prefWidth="650.0" SplitPane.resizableWithParent="true">
+                    <VBox maxWidth="670.0" minHeight="81.0" minWidth="670.0" prefHeight="81.0" prefWidth="670.0" SplitPane.resizableWithParent="true">
                         <padding>
                             <Insets bottom="10" left="10" right="10" top="10" />
                         </padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -30,26 +30,22 @@
         </VBox>
         <AnchorPane>
 
-            <SplitPane dividerPositions="0.2" orientation="VERTICAL" prefWidth="2000.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <SplitPane dividerPositions="0.26582278481012656" orientation="VERTICAL" prefWidth="2000.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
 
                 <!-- @@author -->
-                <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" minHeight="50.0" prefHeight="290.0" prefWidth="870.0">
-                    <VBox minWidth="335.0" prefHeight="290.0" prefWidth="435.0" SplitPane.resizableWithParent="true">
+                <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4269269269269269" minHeight="50.0" prefHeight="290.0" prefWidth="870.0">
+                    <VBox minHeight="81.0" minWidth="650.0" prefHeight="81.0" prefWidth="650.0" SplitPane.resizableWithParent="true">
                         <padding>
                             <Insets bottom="10" left="10" right="10" top="10" />
                         </padding>
 
                         <!-- @@author nbriannl -->
-                        <StackPane fx:id="tagListPanelPlaceholder" maxHeight="80.0" minHeight="20.0" prefHeight="40.0" prefWidth="549.0" styleClass="pane-with-border">
-                            <padding>
-                                <Insets bottom="5" left="10" right="10" top="5" />
-                            </padding>
+                        <StackPane fx:id="tagListPanelPlaceholder" alignment="TOP_CENTER" styleClass="pane-with-border">
+                     <padding>
+                        <Insets bottom="5.0" left="10.0" right="10.0" top="5.0" />
+                     </padding>
                         </StackPane>
-                        <StackPane fx:id="personInfoPlaceholder" VBox.vgrow="ALWAYS">
-                            <padding>
-                                <Insets left="10" right="5" top="5" />
-                            </padding>
-                        </StackPane>
+                        <StackPane fx:id="personInfoPlaceholder" VBox.vgrow="ALWAYS" />
 
                     </VBox>
                     <VBox minWidth="200" prefWidth="323.0">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -42,7 +42,7 @@
                         <!-- @@author nbriannl -->
                         <StackPane fx:id="tagListPanelPlaceholder" alignment="TOP_CENTER" styleClass="pane-with-border">
                      <padding>
-                        <Insets bottom="5.0" left="10.0" right="10.0" top="5.0" />
+                        <Insets bottom="10.0" left="10.0" right="10.0" />
                      </padding>
                         </StackPane>
                         <StackPane fx:id="personInfoPlaceholder" VBox.vgrow="ALWAYS" />

--- a/src/main/resources/view/PersonInfoPanel.fxml
+++ b/src/main/resources/view/PersonInfoPanel.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="250.0" prefWidth="647.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="250.0" prefWidth="650.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
 
     <HBox prefHeight="250.0" prefWidth="448.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <VBox prefHeight="250.0" prefWidth="198.0">

--- a/src/main/resources/view/PersonInfoPanel.fxml
+++ b/src/main/resources/view/PersonInfoPanel.fxml
@@ -65,7 +65,7 @@
                     <VBox.margin>
                         <Insets />
                     </VBox.margin></Label>
-                    <Label fx:id="remark" minHeight="-Infinity" minWidth="-Infinity" prefHeight="20.0" prefWidth="326.0" styleClass="display_small_value" text="\$remark" wrapText="true">
+                    <Label fx:id="remark" styleClass="display_small_value" text="\$remark" wrapText="true">
                     <VBox.margin>
                         <Insets />
                     </VBox.margin></Label>

--- a/src/main/resources/view/PersonInfoPanel.fxml
+++ b/src/main/resources/view/PersonInfoPanel.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="250.0" prefWidth="650.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
 
     <HBox prefHeight="250.0" prefWidth="448.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <VBox prefHeight="250.0" prefWidth="198.0">
@@ -40,9 +40,9 @@
                     <Insets left="15.0" top="20.0" />
                 </VBox.margin>
             </StackPane>
-            <FlowPane fx:id="tags" columnHalignment="CENTER" minHeight="20.0" minWidth="100.0" prefHeight="15.0" prefWidth="207.0" VBox.vgrow="ALWAYS">
+            <FlowPane fx:id="tags" columnHalignment="CENTER">
                 <VBox.margin>
-                    <Insets bottom="0.0" left="15.0" right="10.0" top="0.0" />
+                    <Insets bottom="5.0" left="15.0" right="10.0" />
                 </VBox.margin>
             </FlowPane>
             <HBox prefHeight="100.0" prefWidth="200.0" VBox.vgrow="ALWAYS">

--- a/src/main/resources/view/PersonInfoPanel.fxml
+++ b/src/main/resources/view/PersonInfoPanel.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
-<AnchorPane xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane styleClass="person-info-panel" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
 
     <HBox prefHeight="250.0" prefWidth="448.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <VBox prefHeight="250.0" prefWidth="198.0">

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -7,28 +7,35 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox alignment="CENTER_LEFT" spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
-      <FlowPane fx:id="tags" />
+      <FlowPane fx:id="tags">
+            <VBox.margin>
+               <Insets bottom="5.0" />
+            </VBox.margin></FlowPane>
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
-
-<VBox styleClass="personListBox" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox styleClass="personListBox" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
   <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/TagListPanel.fxml
+++ b/src/main/resources/view/TagListPanel.fxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- @@author nbriannl -->
+
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.FlowPane?>

--- a/src/main/resources/view/TagListPanel.fxml
+++ b/src/main/resources/view/TagListPanel.fxml
@@ -14,7 +14,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
       <padding>
         <Insets bottom="5" left="15" right="5" top="5" />
       </padding>


### PR DESCRIPTION
Fixes #187. Fixes #188. Fixes #204 

Note: All changes are done in 100% display, 1920x1080 resolution

* When first open the app, the app will maximize. And display all panels.
![image](https://user-images.githubusercontent.com/27397021/32689052-6f988dde-c717-11e7-9a9d-9b56453ce652.png)

* All UI elements shift fluidly with tags.
![image](https://user-images.githubusercontent.com/27397021/32689069-cf96fd88-c717-11e7-8c26-3eeefabe1cf2.png)

* Added a divider. (TODO: is to include in the user guide that users can adjust the view using the divider in case of too much info)

* Fixed the vertical divider separating the person card and tags to the command box and result box.

* Made the person card look like a physical card.